### PR TITLE
OpenAPI follow-up

### DIFF
--- a/doc/REST_API.md
+++ b/doc/REST_API.md
@@ -1,5 +1,11 @@
 # pkimetal: REST API Documentation
 
+## OpenAPI
+
+An [OpenAPI](https://swagger.io/specification/) definition for pkimetal is provided by [openapi.yaml](/doc/openapi.yaml).
+
+This powers the Stoplight workspace at https://pkimetal.stoplight.io/docs/pkimetal/68a341c676710-pkimetal-api.
+
 ## POST parameters
 
 The HTTP POST API endpoints all accept the following common parameters:

--- a/doc/openapi.yaml
+++ b/doc/openapi.yaml
@@ -5,11 +5,11 @@ info:
   version: 1.0.0
 
 servers:
-  - url: https://pkimet.al/
+  - url: https://pkimet.al
     description: Stable API server
-  - url: https://dev.pkimet.al/
+  - url: https://dev.pkimet.al
     description: Development API server
-  - url: http://localhost:8080/
+  - url: http://localhost:8080
     description: Local API server
 
 paths:

--- a/doc/openapi.yaml
+++ b/doc/openapi.yaml
@@ -22,6 +22,7 @@ servers:
 paths:
   /lintcert:
     post:
+      operationId: lintcert
       summary: Lints a X.509 certificate
       requestBody:
         $ref: '#/components/requestBodies/LintRequestBody'
@@ -30,6 +31,7 @@ paths:
           $ref: '#/components/responses/LintingSuccessful'
   /linttbscert:
     post:
+      operationId: linttbscert
       summary: Creates and lints a X.509 certificate from the specified TBSCertificate
       requestBody:
         $ref: '#/components/requestBodies/LintRequestBody'
@@ -39,6 +41,7 @@ paths:
   
   /lintcrl:
     post:
+      operationId: lintcrl
       summary: Lints a X.509 certificate revocation list (CRL)
       requestBody:
         $ref: '#/components/requestBodies/LintRequestBody'
@@ -47,6 +50,7 @@ paths:
           $ref: '#/components/responses/LintingSuccessful'
   /linttbscrl:
     post:
+      operationId: linttbscrl
       summary: Creates and lints a X.509 certificate revocation list (CRL) from the specified TBSCertList
       requestBody:
         $ref: '#/components/requestBodies/LintRequestBody'
@@ -56,6 +60,7 @@ paths:
 
   /lintocsp:
     post:
+      operationId: lintocsp
       summary: Lints an OCSP response
       requestBody:
         $ref: '#/components/requestBodies/LintRequestBody'
@@ -64,6 +69,7 @@ paths:
           $ref: '#/components/responses/LintingSuccessful'
   /linttbsocsp:
     post:
+      operationId: linttbsocsp
       summary: Creates and lints an OCSP response from the specified ResponseData
       requestBody:
         $ref: '#/components/requestBodies/LintRequestBody'
@@ -73,6 +79,7 @@ paths:
           
   /profiles:
     get:
+      operationId: profiles
       summary: Retrieves the profiles available for linting
       responses:
         '200':
@@ -86,6 +93,7 @@ paths:
                   
   /linters:
     get:
+      operationId: linters
       summary: Retrieves the linters available for linting
       responses:
         '200':

--- a/doc/openapi.yaml
+++ b/doc/openapi.yaml
@@ -24,6 +24,8 @@ paths:
     post:
       operationId: lintcert
       description: Lints a X.509 certificate
+      tags:
+        - cert
       requestBody:
         $ref: '#/components/requestBodies/LintRequestBody'
       responses:
@@ -33,6 +35,8 @@ paths:
     post:
       operationId: linttbscert
       description: Creates and lints a X.509 certificate from the specified TBSCertificate
+      tags:
+        - cert
       requestBody:
         $ref: '#/components/requestBodies/LintRequestBody'
       responses:
@@ -43,6 +47,8 @@ paths:
     post:
       operationId: lintcrl
       description: Lints a X.509 certificate revocation list (CRL)
+      tags:
+        - crl
       requestBody:
         $ref: '#/components/requestBodies/LintRequestBody'
       responses:
@@ -52,6 +58,8 @@ paths:
     post:
       operationId: linttbscrl
       description: Creates and lints a X.509 certificate revocation list (CRL) from the specified TBSCertList
+      tags:
+        - crl
       requestBody:
         $ref: '#/components/requestBodies/LintRequestBody'
       responses:
@@ -62,6 +70,8 @@ paths:
     post:
       operationId: lintocsp
       description: Lints an OCSP response
+      tags:
+        - ocsp
       requestBody:
         $ref: '#/components/requestBodies/LintRequestBody'
       responses:
@@ -71,6 +81,8 @@ paths:
     post:
       operationId: linttbsocsp
       description: Creates and lints an OCSP response from the specified ResponseData
+      tags:
+        - ocsp
       requestBody:
         $ref: '#/components/requestBodies/LintRequestBody'
       responses:
@@ -81,6 +93,8 @@ paths:
     get:
       operationId: profiles
       description: Retrieves the profiles available for linting
+      tags:
+        - meta
       responses:
         '200':
           description: A list of profiles available for linting
@@ -95,6 +109,8 @@ paths:
     get:
       operationId: linters
       description: Retrieves the linters available for linting
+      tags:
+        - meta
       responses:
         '200':
           description: A list of linters available for linting
@@ -230,3 +246,13 @@ components:
           type: string
           format: uri
           description: The home page for the linter project
+
+tags:
+  - name: cert
+    description: Operations related to X.509 certificates
+  - name: crl
+    description: Operations related to X.509 certificate revocation lists (CRLs)
+  - name: meta
+    description: Operations related to pkimetal itself
+  - name: ocsp
+    description: Operations related to OCSP responses

--- a/doc/openapi.yaml
+++ b/doc/openapi.yaml
@@ -2,6 +2,10 @@ openapi: 3.0.0
 info:
   title: pkimetal API
   description: PKI Meta-Linter
+  contact:
+    name: Rob Stradling
+    email: rob@sectigo.com
+    url: https://github.com/pkimetal/pkimetal/blob/main/README.md#about-this-project
   version: 1.0.0
 
 servers:

--- a/doc/openapi.yaml
+++ b/doc/openapi.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.0
+openapi: 3.1.0
 info:
   title: pkimetal API
   description: PKI Meta-Linter
@@ -9,7 +9,7 @@ info:
   license:
     name: GNU General Public License v3.0 or later
     url: https://spdx.org/licenses/GPL-3.0-or-later.html
-  version: 1.0.0
+  version: 1.0.1
 
 servers:
   - url: https://pkimet.al

--- a/doc/openapi.yaml
+++ b/doc/openapi.yaml
@@ -1,4 +1,4 @@
-openapi: 3.1.0
+openapi: 3.0.0
 info:
   title: pkimetal API
   description: PKI Meta-Linter

--- a/doc/openapi.yaml
+++ b/doc/openapi.yaml
@@ -6,6 +6,9 @@ info:
     name: Rob Stradling
     email: rob@sectigo.com
     url: https://github.com/pkimetal/pkimetal/blob/main/README.md#about-this-project
+  license:
+    name: GNU General Public License v3.0 or later
+    url: https://spdx.org/licenses/GPL-3.0-or-later.html
   version: 1.0.0
 
 servers:

--- a/doc/openapi.yaml
+++ b/doc/openapi.yaml
@@ -23,6 +23,7 @@ paths:
   /lintcert:
     post:
       operationId: lintcert
+      summary: Lint a Certificate
       description: Lints a X.509 certificate
       tags:
         - cert
@@ -34,6 +35,7 @@ paths:
   /linttbscert:
     post:
       operationId: linttbscert
+      summary: Lint a to-be-signed Certificate
       description: Creates and lints a X.509 certificate from the specified TBSCertificate
       tags:
         - cert
@@ -46,6 +48,7 @@ paths:
   /lintcrl:
     post:
       operationId: lintcrl
+      summary: Lint a CRL
       description: Lints a X.509 certificate revocation list (CRL)
       tags:
         - crl
@@ -57,6 +60,7 @@ paths:
   /linttbscrl:
     post:
       operationId: linttbscrl
+      summary: Lint a to-be-signed CRL
       description: Creates and lints a X.509 certificate revocation list (CRL) from the specified TBSCertList
       tags:
         - crl
@@ -69,6 +73,7 @@ paths:
   /lintocsp:
     post:
       operationId: lintocsp
+      summary: Lint an OCSP Response
       description: Lints an OCSP response
       tags:
         - ocsp
@@ -80,6 +85,7 @@ paths:
   /linttbsocsp:
     post:
       operationId: linttbsocsp
+      summary: Lint a to-be-signed OCSP Response
       description: Creates and lints an OCSP response from the specified ResponseData
       tags:
         - ocsp
@@ -92,6 +98,7 @@ paths:
   /profiles:
     get:
       operationId: profiles
+      summary: List linting profiles
       description: Retrieves the profiles available for linting
       tags:
         - meta
@@ -108,6 +115,7 @@ paths:
   /linters:
     get:
       operationId: linters
+      summary: List linters
       description: Retrieves the linters available for linting
       tags:
         - meta

--- a/doc/openapi.yaml
+++ b/doc/openapi.yaml
@@ -23,7 +23,7 @@ paths:
   /lintcert:
     post:
       operationId: lintcert
-      summary: Lints a X.509 certificate
+      description: Lints a X.509 certificate
       requestBody:
         $ref: '#/components/requestBodies/LintRequestBody'
       responses:
@@ -32,7 +32,7 @@ paths:
   /linttbscert:
     post:
       operationId: linttbscert
-      summary: Creates and lints a X.509 certificate from the specified TBSCertificate
+      description: Creates and lints a X.509 certificate from the specified TBSCertificate
       requestBody:
         $ref: '#/components/requestBodies/LintRequestBody'
       responses:
@@ -42,7 +42,7 @@ paths:
   /lintcrl:
     post:
       operationId: lintcrl
-      summary: Lints a X.509 certificate revocation list (CRL)
+      description: Lints a X.509 certificate revocation list (CRL)
       requestBody:
         $ref: '#/components/requestBodies/LintRequestBody'
       responses:
@@ -51,7 +51,7 @@ paths:
   /linttbscrl:
     post:
       operationId: linttbscrl
-      summary: Creates and lints a X.509 certificate revocation list (CRL) from the specified TBSCertList
+      description: Creates and lints a X.509 certificate revocation list (CRL) from the specified TBSCertList
       requestBody:
         $ref: '#/components/requestBodies/LintRequestBody'
       responses:
@@ -61,7 +61,7 @@ paths:
   /lintocsp:
     post:
       operationId: lintocsp
-      summary: Lints an OCSP response
+      description: Lints an OCSP response
       requestBody:
         $ref: '#/components/requestBodies/LintRequestBody'
       responses:
@@ -70,7 +70,7 @@ paths:
   /linttbsocsp:
     post:
       operationId: linttbsocsp
-      summary: Creates and lints an OCSP response from the specified ResponseData
+      description: Creates and lints an OCSP response from the specified ResponseData
       requestBody:
         $ref: '#/components/requestBodies/LintRequestBody'
       responses:
@@ -80,7 +80,7 @@ paths:
   /profiles:
     get:
       operationId: profiles
-      summary: Retrieves the profiles available for linting
+      description: Retrieves the profiles available for linting
       responses:
         '200':
           description: A list of profiles available for linting
@@ -94,7 +94,7 @@ paths:
   /linters:
     get:
       operationId: linters
-      summary: Retrieves the linters available for linting
+      description: Retrieves the linters available for linting
       responses:
         '200':
           description: A list of linters available for linting


### PR DESCRIPTION
Following on from #80, this PR updates pkimetal's `openapi.yaml` to resolve all of the warnings emitted by the https://stoplight.io/open-source/spectral linter.  It also updates `REST_API.md` to mention `openapi.yaml` and its instantiation at https://pkimetal.stoplight.io/docs/pkimetal/68a341c676710-pkimetal-api.

@CBonnell and @sigmavirus24: Does this look OK to you?

BTW, https://pkimetal.stoplight.io/docs/pkimetal/68a341c676710-pkimetal-api is currently running the version of `openapi.yaml` in this PR.