### PR TITLE
fix: Actually call lint_etsi_cert for ETSI certificate profiles, and only filter 'superseded' findings for 'non browser' profiles.

### DIFF
--- a/linter/profile.go
+++ b/linter/profile.go
@@ -230,8 +230,11 @@ var (
 		ETSI_LEAF_NCPLEGALPERSON:                                         {Name: "etsi_leaf_ncplegalperson", Source: "EN 319 412", Description: "ETSI Electronic Seal Certificate: Legal Person "},
 	}
 
-	AllProfilesOrdered                                                                                                                                                                                                                                        []Profile
-	CrlProfileIDs, OcspProfileIDs, RootProfileIDs, SubordinateProfileIDs, SbrLeafProfileIDs, TbrTevgLeafProfileIDs, TbrTevgCertificateProfileIDs, NonTbrTevgCertificateProfileIDs, NonCabforumProfileIDs, NonCertificateProfileIDs, EtsiCertificateProfileIDs []ProfileId
+	AllProfilesOrdered                                                               []Profile
+	CrlProfileIDs, OcspProfileIDs, RootProfileIDs, SubordinateProfileIDs             []ProfileId
+	SbrLeafProfileIDs, TbrTevgLeafProfileIDs, TbrTevgCertificateProfileIDs           []ProfileId
+	NonTbrTevgCertificateProfileIDs, NonCabforumProfileIDs, NonCertificateProfileIDs []ProfileId
+	EtsiCertificateProfileIDs, EtsiNonBrowserCertificateProfileIDs                   []ProfileId
 )
 
 func init() {
@@ -262,6 +265,9 @@ func init() {
 
 		if strings.HasPrefix(v.Name, "etsi_") {
 			EtsiCertificateProfileIDs = append(EtsiCertificateProfileIDs, k)
+			if strings.Contains(v.Name, "nonbrowser") {
+				EtsiNonBrowserCertificateProfileIDs = append(EtsiNonBrowserCertificateProfileIDs, k)
+			}
 		}
 	}
 


### PR DESCRIPTION
https://github.com/pkimetal/pkimetal/commit/0cacfa53d9156bc08d75b6c6ba6aa45f96c80b9b integrated pkilint's lint_etsi_cert functionality in [pkilint/handler.go](https://github.com/pkimetal/pkimetal/blob/main/linter/pkilint/handler.go), but neglected to add code to actually call this functionality for ETSI profiles.  Consequently, prior to this PR, pkimetal has been calling lint_cabf_serverauth_cert or lint_pkix_cert for ETSI profiles.

This PR also implements equivalent functionality for the `--report-all` parameter from pkilint's lint_etsi_cert.  This parameter is set automatically depending on whether or not the selected ETSI profile is "non browser".