### PR TITLE
release: Add linux/arm64 to list of platforms

### DIFF
--- a/.github/workflows/docker-dev.yml
+++ b/.github/workflows/docker-dev.yml
@@ -66,6 +66,7 @@ jobs:
           cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
           tags: ghcr.io/pkimetal/pkimetal-dev:${{ env.CONTAINER_TIMESTAMP }}
           labels: ghcr.io/pkimetal/pkimetal-dev:${{ env.CONTAINER_TIMESTAMP }}
+          platforms: linux/amd64,linux/arm64
           provenance: false
 
       # Temp fix

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -68,6 +68,7 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
           provenance: false
 
       # Temp fix


### PR DESCRIPTION
Publish a linux/arm64 image for testing locally on modern Apple hardware.