### PR TITLE
dockerfile: Add missing dependencies for local builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ ARG gomodfile
 # Install build dependencies.
 RUN apk add --no-cache --update \
 	# Common.
-	gcc git g++ make \
+	gcc g++ make musl-dev pkgconfig \
+	git \
 	# certlint.
 	ruby ruby-dev \
 	# badkeys, ftfy, and pkilint.
@@ -13,7 +14,9 @@ RUN apk add --no-cache --update \
 	# pkilint (for pyasn1-fasder).
 	rustup \
 	# x509lint.
-	openssl-dev
+	openssl-dev \
+	# badkeys/rsakeys/fermat.py.
+	gmp-dev mpfr-dev mpc1-dev
 
 # Configure environment.
 ENV PATH="/root/.local/bin:/root/.cargo/bin:${PATH}"
@@ -96,7 +99,11 @@ RUN apk add --no-cache --update \
 	# pkilint and ftfy.
 	python3 \
 	# certlint.
-	ruby && \
+	ruby \
+	# badkeys/rsakeys/fermat.py.
+	gmp \
+	mpfr \
+	mpc1 && \
 	gem install public_suffix simpleidn && \
 	# badkeys.
 	adduser -D pkimetal


### PR DESCRIPTION
- Add `gmpy2`, imported by badkeys ([rsakeys/fermat](https://github.com/badkeys/badkeys/blob/main/badkeys/rsakeys/fermat.py#L1)), which requires `gmp-dev`, `mpfr-dev`, and `libmpc-dev` ([mpc1-dev](https://pkgs.alpinelinux.org/package/edge/main/x86_64/mpc1-dev)).
- Add git

Note: FWIW I see this is building fine on `linux/amd64` in GitHub workflows, but when building locally on `linux/arm64` I had to address these missing dependencies before I could achieve a successful build.