### PR TITLE
Allow pkimetal to listen on a Unix socket

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -19,7 +19,10 @@ import (
 type config struct {
 	Server struct {
 		WebserverPort       int           `mapstructure:"webserverPort"`
+		WebserverPath       string        `mapstructure:"webserverPath"`
 		MonitoringPort      int           `mapstructure:"monitoringPort"`
+		MonitoringPath      string        `mapstructure:"monitoringPath"`
+		SocketPermissions   os.FileMode   `mapstructure:"socketPermissions"`
 		ReadTimeout         time.Duration `mapstructure:"readTimeout"`
 		IdleTimeout         time.Duration `mapstructure:"idleTimeout"`
 		DisableKeepalive    bool          `mapstructure:"disableKeepalive"`
@@ -188,6 +191,7 @@ func initViper() error {
 	// Set defaults for all values in-order to use env config for all options.
 	viper.SetDefault("server.webserverPort", 8080)
 	viper.SetDefault("server.monitoringPort", 8081)
+	viper.SetDefault("server.socketPermissions", 0o600)
 	viper.SetDefault("server.readTimeout", 30*time.Second)
 	viper.SetDefault("server.idleTimeout", 30*time.Second)
 	viper.SetDefault("server.disableKeepalive", false)


### PR DESCRIPTION
We'd like to run pkimetal in parts of our CA infrastructure as a sidecar to another process, and instead of worrying about networking, we would prefer to just use a unix socket.

This adds three new configuration parameters:

 * server.webserverPath (no default)
 * server.monitoringPath (no default)
 * server.socketPermissions (default 0600)

If these are set, pkimetal will listen for requests on those unix sockets. Listening in a port is now also conditional on the port being nonzero. With a default configuration, nothing changes.

I've added logging of the port/path listening to make it clearer what's happening.

The server.socketPermission sets the default permissions on the socket. 0600 is a conservative default, and users can permit more open permissions.

I've been interactively testing this change like this:

     curl --unix-socket /tmp/pkimetal.sock http://x/lintcert \
          --data-urlencode b64input@cert.pem
