### PR TITLE
Dockerfile: pin Alpine version in both stages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # BUILD.
-FROM docker.io/library/golang:1.26.4-alpine AS build
+FROM docker.io/library/golang:1.26.4-alpine3.23 AS build
 
 # Install build dependencies.
 RUN apk add --no-cache busybox && \
@@ -94,7 +94,7 @@ RUN git fetch --depth=2147483647 && \
 
 
 # RUNTIME.
-FROM alpine:latest AS runtime
+FROM alpine:3.23 AS runtime
 
 # Configure environment.
 CMD ["/app/pkimetal"]


### PR DESCRIPTION
Pin the Alpine version to 3.23 in the BUILD and RUNTIME stages to ensure both use the same Python version. Previously, the RUNTIME stage used `alpine:latest`, which could advance to a newer Alpine release (and a different Python version) independently of the BUILD stage's `golang:*-alpine` image. This mismatch caused the Python virtual environments (badkeys, pkilint, ftfy) built in the BUILD stage to be incompatible with the RUNTIME stage's Python interpreter, resulting in `ModuleNotFoundError: No module named '_cffi_backend'` errors due to ABI incompatibility between Python 3.12 and 3.14.