### PR TITLE
Fix zlint arl nextupdate

### DIFF
--- a/linter/profile.go
+++ b/linter/profile.go
@@ -251,6 +251,7 @@ var (
 	AllProfilesOrdered                                                               []Profile
 	CrlProfileIDs, OcspProfileIDs, RootProfileIDs, SubordinateProfileIDs             []ProfileId
 	SbrLeafProfileIDs, TbrTevgLeafProfileIDs, TbrTevgCertificateProfileIDs           []ProfileId
+	TbrTevgARLProfileIDs                                                             []ProfileId
 	NonTbrTevgCertificateProfileIDs, NonCabforumProfileIDs, NonCertificateProfileIDs []ProfileId
 	MarkCertificateProfileIDs                                                        []ProfileId
 	EtsiCertificateProfileIDs, EtsiNonBrowserCertificateProfileIDs                   []ProfileId
@@ -262,6 +263,9 @@ func init() {
 	for k, v := range AllProfiles {
 		if strings.HasSuffix(v.Name, "_crl") || strings.HasSuffix(v.Name, "_arl") {
 			CrlProfileIDs = append(CrlProfileIDs, k)
+			if (strings.HasPrefix(v.Name, "tbr_") || strings.HasPrefix(v.Name, "tevg_")) && strings.HasSuffix(v.Name, "_arl") {
+				TbrTevgARLProfileIDs = append(TbrTevgARLProfileIDs, k)
+			}
 		} else if strings.HasSuffix(v.Name, "_ocspresponse") {
 			OcspProfileIDs = append(OcspProfileIDs, k)
 		} else if strings.Contains(v.Name, "_root_") || strings.HasSuffix(v.Name, "_root") {

--- a/linter/profile.go
+++ b/linter/profile.go
@@ -251,7 +251,7 @@ var (
 	AllProfilesOrdered                                                               []Profile
 	CrlProfileIDs, OcspProfileIDs, RootProfileIDs, SubordinateProfileIDs             []ProfileId
 	SbrLeafProfileIDs, TbrTevgLeafProfileIDs, TbrTevgCertificateProfileIDs           []ProfileId
-	TbrTevgARLProfileIDs                                                             []ProfileId
+	TbrARLProfileIDs                                                                 []ProfileId
 	NonTbrTevgCertificateProfileIDs, NonCabforumProfileIDs, NonCertificateProfileIDs []ProfileId
 	MarkCertificateProfileIDs                                                        []ProfileId
 	EtsiCertificateProfileIDs, EtsiNonBrowserCertificateProfileIDs                   []ProfileId
@@ -263,9 +263,6 @@ func init() {
 	for k, v := range AllProfiles {
 		if strings.HasSuffix(v.Name, "_crl") || strings.HasSuffix(v.Name, "_arl") {
 			CrlProfileIDs = append(CrlProfileIDs, k)
-			if (strings.HasPrefix(v.Name, "tbr_") || strings.HasPrefix(v.Name, "tevg_")) && strings.HasSuffix(v.Name, "_arl") {
-				TbrTevgARLProfileIDs = append(TbrTevgARLProfileIDs, k)
-			}
 		} else if strings.HasSuffix(v.Name, "_ocspresponse") {
 			OcspProfileIDs = append(OcspProfileIDs, k)
 		} else if strings.Contains(v.Name, "_root_") || strings.HasSuffix(v.Name, "_root") {
@@ -278,6 +275,10 @@ func init() {
 			TbrTevgLeafProfileIDs = append(TbrTevgLeafProfileIDs, k)
 		} else if strings.HasPrefix(v.Name, "bimigroup_") {
 			MarkCertificateProfileIDs = append(MarkCertificateProfileIDs, k)
+		}
+
+		if k == TBR_ARL {
+			TbrARLProfileIDs = append(TbrARLProfileIDs, k)
 		}
 	}
 

--- a/linter/zlint/handler.go
+++ b/linter/zlint/handler.go
@@ -24,6 +24,7 @@ var (
 	defaultRegistry                lint.Registry
 	cabforumTLSSubordinateRegistry lint.Registry
 	cabforumTLSLeafRegistry        lint.Registry
+	cabforumTLSARLRegistry         lint.Registry
 	notCabforumRegistry            lint.Registry
 )
 
@@ -54,6 +55,20 @@ func init() {
 	}); err != nil {
 		logger.Logger.Fatal("Failed to configure filtered zlint registry for BR/EVG TLS Server leaf certificates", zap.Error(err))
 	}
+
+	if cabforumTLSARLRegistry, err = defaultRegistry.Filter(lint.FilterOptions{
+		IncludeNames: defaultRegistry.Names(),
+	}); err != nil {
+		logger.Logger.Fatal("Failed to configure filtered zlint registry for BR/EVG TLS Server authority revocation lists", zap.Error(err))
+	}
+	arlConfig, err := lint.NewConfigFromString(`
+[e_crl_next_update_invalid]
+SubscriberCRL = false
+`)
+	if err != nil {
+		logger.Logger.Fatal("Failed to configure zlint CRL nextUpdate lint for BR/EVG TLS Server authority revocation lists", zap.Error(err))
+	}
+	cabforumTLSARLRegistry.SetConfiguration(arlConfig)
 
 	// Filter out CABForum lints for non-CABForum profiles.
 	if notCabforumRegistry, err = defaultRegistry.Filter(lint.FilterOptions{
@@ -172,6 +187,8 @@ func (l *Zlint) HandleRequest(ctx context.Context, lin *linter.LinterInstance, l
 		registry = &cabforumTLSLeafRegistry
 	} else if slices.Contains(linter.TbrTevgCertificateProfileIDs, lreq.ProfileId) {
 		registry = &cabforumTLSSubordinateRegistry
+	} else if slices.Contains(linter.TbrTevgARLProfileIDs, lreq.ProfileId) {
+		registry = &cabforumTLSARLRegistry
 	} else if slices.Contains(linter.NonCabforumProfileIDs, lreq.ProfileId) {
 		registry = &notCabforumRegistry
 	} else {

--- a/linter/zlint/handler.go
+++ b/linter/zlint/handler.go
@@ -187,7 +187,7 @@ func (l *Zlint) HandleRequest(ctx context.Context, lin *linter.LinterInstance, l
 		registry = &cabforumTLSLeafRegistry
 	} else if slices.Contains(linter.TbrTevgCertificateProfileIDs, lreq.ProfileId) {
 		registry = &cabforumTLSSubordinateRegistry
-	} else if slices.Contains(linter.TbrTevgARLProfileIDs, lreq.ProfileId) {
+	} else if slices.Contains(linter.TbrARLProfileIDs, lreq.ProfileId) {
 		registry = &cabforumTLSARLRegistry
 	} else if slices.Contains(linter.NonCabforumProfileIDs, lreq.ProfileId) {
 		registry = &notCabforumRegistry

--- a/linter/zlint/handler.go
+++ b/linter/zlint/handler.go
@@ -59,14 +59,14 @@ func init() {
 	if cabforumTLSARLRegistry, err = defaultRegistry.Filter(lint.FilterOptions{
 		IncludeNames: defaultRegistry.Names(),
 	}); err != nil {
-		logger.Logger.Fatal("Failed to configure filtered zlint registry for BR/EVG TLS Server authority revocation lists", zap.Error(err))
+		logger.Logger.Fatal("Failed to configure filtered zlint registry for BR TLS Server authority revocation lists", zap.Error(err))
 	}
 	arlConfig, err := lint.NewConfigFromString(`
 [e_crl_next_update_invalid]
 SubscriberCRL = false
 `)
 	if err != nil {
-		logger.Logger.Fatal("Failed to configure zlint CRL nextUpdate lint for BR/EVG TLS Server authority revocation lists", zap.Error(err))
+		logger.Logger.Fatal("Failed to configure zlint CRL nextUpdate lint for BR TLS Server authority revocation lists", zap.Error(err))
 	}
 	cabforumTLSARLRegistry.SetConfiguration(arlConfig)
 

--- a/linter/zlint/handler_test.go
+++ b/linter/zlint/handler_test.go
@@ -1,0 +1,96 @@
+package zlint
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	cryptox509 "crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/pkimetal/pkimetal/linter"
+)
+
+func testCRLDER(t *testing.T, thisUpdate, nextUpdate time.Time) []byte {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate test key: %v", err)
+	}
+
+	issuer := &cryptox509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test issuer"},
+		NotBefore:             thisUpdate.Add(-time.Hour),
+		NotAfter:              nextUpdate.Add(time.Hour),
+		KeyUsage:              cryptox509.KeyUsageCertSign | cryptox509.KeyUsageCRLSign,
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		SubjectKeyId:          []byte{1, 2, 3, 4},
+	}
+
+	crl := &cryptox509.RevocationList{
+		SignatureAlgorithm: cryptox509.SHA256WithRSA,
+		Number:             big.NewInt(1),
+		ThisUpdate:         thisUpdate,
+		NextUpdate:         nextUpdate,
+	}
+	der, err := cryptox509.CreateRevocationList(rand.Reader, crl, issuer, key)
+	if err != nil {
+		t.Fatalf("failed to generate test CRL: %v", err)
+	}
+	return der
+}
+
+func hasFinding(results []linter.LintingResult, code string) bool {
+	for _, result := range results {
+		if result.Code == code {
+			return true
+		}
+	}
+	return false
+}
+
+func TestTBRCRLUsesSubscriberCRLNextUpdateLimit(t *testing.T) {
+	thisUpdate := time.Date(2026, time.June, 24, 13, 0, 0, 0, time.UTC)
+
+	validCRLResults := (&Zlint{}).HandleRequest(context.Background(), nil, &linter.LintingRequest{
+		DecodedInput: testCRLDER(t, thisUpdate, thisUpdate.AddDate(0, 0, 9)),
+		ProfileId:    linter.TBR_CRL,
+	})
+	if hasFinding(validCRLResults, "e_crl_next_update_invalid") {
+		t.Fatal("TBR CRL reported nextUpdate limit violation for a 9-day subscriber CRL")
+	}
+
+	invalidCRLResults := (&Zlint{}).HandleRequest(context.Background(), nil, &linter.LintingRequest{
+		DecodedInput: testCRLDER(t, thisUpdate, thisUpdate.AddDate(0, 0, 11)),
+		ProfileId:    linter.TBR_CRL,
+	})
+	if !hasFinding(invalidCRLResults, "e_crl_next_update_invalid") {
+		t.Fatal("TBR CRL did not report nextUpdate limit violation for an 11-day subscriber CRL")
+	}
+}
+
+func TestTBRARLUsesCACRLNextUpdateLimit(t *testing.T) {
+	thisUpdate := time.Date(2026, time.June, 24, 13, 0, 0, 0, time.UTC)
+	crlDER := testCRLDER(t, thisUpdate, thisUpdate.AddDate(0, 11, 0))
+
+	crlResults := (&Zlint{}).HandleRequest(context.Background(), nil, &linter.LintingRequest{
+		DecodedInput: crlDER,
+		ProfileId:    linter.TBR_CRL,
+	})
+	if !hasFinding(crlResults, "e_crl_next_update_invalid") {
+		t.Fatal("TBR CRL did not report subscriber nextUpdate limit violation")
+	}
+
+	arlResults := (&Zlint{}).HandleRequest(context.Background(), nil, &linter.LintingRequest{
+		DecodedInput: crlDER,
+		ProfileId:    linter.TBR_ARL,
+	})
+	if hasFinding(arlResults, "e_crl_next_update_invalid") {
+		t.Fatal("TBR ARL reported subscriber nextUpdate limit violation")
+	}
+}


### PR DESCRIPTION
This fixes pkimetal’s zlint handling for the tbr_arl profile.

Previously, tbr_arl used zlint’s default CRL configuration for e_crl_next_update_invalid, which treats the input as a subscriber/leaf
CRL and applies the 10-day nextUpdate limit. ARLs cover CA certificates and should use the TLS BR CA/ARL limit of 12 months.

Changes:

- Add a separate zlint registry for TLS BR ARLs.
- Configure e_crl_next_update_invalid with SubscriberCRL = false for tbr_arl.
- Keep tbr_crl on the default subscriber CRL 10-day rule.
- Add tests for both subscriber CRL and ARL nextUpdate behavior.

Validation

go test ./linter ./linter/zlint -v

Also manually tested with mock CRLs against pkimetal:

- tbr_crl accepts a 9-day subscriber CRL and rejects an 11-day subscriber CRL.
- tbr_arl accepts an 11-month ARL and rejects a 13-month ARL.