### PR TITLE
pkilint: avoid quadratic PEM input assembly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,9 @@ jobs:
         env:
           CGO_ENABLED: "1"
 
+      - name: Python input protocol tests
+        run: python3 -m unittest discover -s linter/pkilint -p 'test_*.py'
+
   smoke:
     name: Container smoke test
     # docker-dev.yml already builds and smoke-tests the image on main, so only run

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ go.work
 
 .vscode/
 node_modules
+__pycache__/

--- a/linter/pkilint/handler.go
+++ b/linter/pkilint/handler.go
@@ -2,6 +2,7 @@ package pkilint
 
 import (
 	"context"
+	_ "embed"
 	"fmt"
 
 	"github.com/pkimetal/pkimetal/config"
@@ -11,6 +12,9 @@ import (
 type Pkilint struct{}
 
 var Version, PythonDir string
+
+//go:embed pem_input.py
+var pemInputReader string
 
 func init() {
 	// Get pkilint package details, either embedded during the build process or from pipx; if requested in the config, autodetect the site-packages directory.
@@ -54,6 +58,7 @@ from pkilint.etsi import etsi_constants
 from pkilint.pkix import certificate, crl, extension, name, ocsp
 from pkilint.report import ReportGeneratorJson
 
+` + pemInputReader + `
 
 # lint_cabf_smime_cert:
 ` + smime_profile_dictionary + `
@@ -186,35 +191,26 @@ def lint_ocsp_response(pem_data):
 		return "F: Exception: " + str(e)
 
 
-profile_id = -1
-pem_data = ""
 try:
 	init_smime_validators()
 	init_serverauth_validators_and_filters()
 	init_etsi_validators_and_filters()
 	print("` + linter.PKIMETAL_READY + `", flush=True)
-	for line in stdin:
-		if profile_id == -1:
-			profile_id = int(line.strip())
+	for profile_id, pem_data in read_pem_requests(stdin):
+		if profile_id in etsi_profile_ids:
+			print(lint_etsi_cert(profile_id, profile_id not in etsi_non_browser_profile_ids, pem_data))
+		elif profile_id in sbr_profile_ids:
+			print(lint_cabf_smime_cert(profile_id, pem_data))
+		elif profile_id in tbr_tevg_profile_ids:
+			print(lint_cabf_serverauth_cert(profile_id, pem_data))
+		elif profile_id in crl_profile_ids:
+			print(lint_crl(pem_data, profile_id))
+		elif profile_id in ocspresponse_profile_ids:
+			print(lint_ocsp_response(pem_data))
 		else:
-			pem_data = pem_data + line.strip() + "\n"
-
-		if "END CERTIFICATE" in line or "END X509 CRL" in line or "END OCSP RESPONSE" in line:
-			if profile_id in etsi_profile_ids:
-				print(lint_etsi_cert(profile_id, profile_id not in etsi_non_browser_profile_ids, pem_data))
-			elif profile_id in sbr_profile_ids:
-				print(lint_cabf_smime_cert(profile_id, pem_data))
-			elif profile_id in tbr_tevg_profile_ids:
-				print(lint_cabf_serverauth_cert(profile_id, pem_data))
-			elif profile_id in crl_profile_ids:
-				print(lint_crl(pem_data, profile_id))
-			elif profile_id in ocspresponse_profile_ids:
-				print(lint_ocsp_response(pem_data))
-			else:
-				print(lint_pkix_cert(pem_data))
-			print("` + linter.PKIMETAL_ENDOFRESULTS + `", flush=True)
-			profile_id = -1
-			pem_data = ""
+			print(lint_pkix_cert(pem_data))
+		print("` + linter.PKIMETAL_ENDOFRESULTS + `", flush=True)
+		del pem_data
 except KeyboardInterrupt:
 	pass
 `}

--- a/linter/pkilint/pem_input.py
+++ b/linter/pkilint/pem_input.py
@@ -1,0 +1,18 @@
+def read_pem_requests(stream):
+    """Read the profile/PEM protocol without repeatedly copying the input."""
+    profile_id = None
+    pem_lines = []
+    for line in stream:
+        if profile_id is None:
+            profile_id = int(line.strip())
+        else:
+            pem_lines.append(line.strip() + "\n")
+
+        if (
+            "END CERTIFICATE" in line
+            or "END X509 CRL" in line
+            or "END OCSP RESPONSE" in line
+        ):
+            yield profile_id, "".join(pem_lines)
+            profile_id = None
+            pem_lines.clear()

--- a/linter/pkilint/test_pem_input.py
+++ b/linter/pkilint/test_pem_input.py
@@ -1,0 +1,49 @@
+import io
+import unittest
+
+from pem_input import read_pem_requests
+
+
+class ReadPemRequestsTest(unittest.TestCase):
+    def test_multiple_requests_and_all_supported_types(self):
+        expected = [
+            (3, "-----BEGIN CERTIFICATE-----\nYWJj\n-----END CERTIFICATE-----\n"),
+            (32, "-----BEGIN X509 CRL-----\nZGVm\n-----END X509 CRL-----\n"),
+            (13, "-----BEGIN OCSP RESPONSE-----\nZ2hp\n-----END OCSP RESPONSE-----\n"),
+        ]
+        wire = "".join(f"{profile}\n{pem}" for profile, pem in expected)
+        self.assertEqual(list(read_pem_requests(io.StringIO(wire))), expected)
+
+    def test_whitespace_and_crlf_are_normalized(self):
+        wire = (
+            " 32 \r\n  -----BEGIN X509 CRL----- \r\n"
+            "\tYWJj \r\n -----END X509 CRL----- \r\n"
+        )
+        expected = "-----BEGIN X509 CRL-----\nYWJj\n-----END X509 CRL-----\n"
+        self.assertEqual(list(read_pem_requests(io.StringIO(wire))), [(32, expected)])
+
+    def test_large_request_followed_by_small_request(self):
+        # Roughly 6 MiB of PEM, followed by another request on the same worker.
+        large = (
+            "-----BEGIN X509 CRL-----\n"
+            + ("A" * 64 + "\n") * 100000
+            + "-----END X509 CRL-----\n"
+        )
+        small = "-----BEGIN X509 CRL-----\nYWJj\n-----END X509 CRL-----\n"
+        wire = f"32\n{large}11\n{small}"
+        self.assertEqual(
+            list(read_pem_requests(io.StringIO(wire))), [(32, large), (11, small)]
+        )
+
+    def test_incomplete_input_is_not_dispatched(self):
+        for wire in ["", "32\n", "32\n-----BEGIN X509 CRL-----\nYWJj\n"]:
+            with self.subTest(wire=wire):
+                self.assertEqual(list(read_pem_requests(io.StringIO(wire))), [])
+
+    def test_invalid_profile_is_rejected(self):
+        with self.assertRaises(ValueError):
+            list(read_pem_requests(io.StringIO("invalid\n")))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Large CRLs cause the pkilint worker to repeatedly copy the entire accumulated PEM string for every input line, making input assembly quadratic in the payload size.

Collect normalized PEM lines and join them once per request in an embedded Python reader. The change preserves profile dispatch, supported PEM boundaries, whitespace normalization, and the response protocol, and releases the assembled payload after each response. Five standard-library tests cover all supported input types, consecutive requests, a roughly 6 MiB payload, CRLF/whitespace handling, incomplete input, and invalid profile IDs; CI now runs these tests.

### Performance

Local measurements with warmed Python workers on macOS arm64, Python 3.12.13, pkilint 0.13.3, and pyasn1-fasder 0.1.3:

| Revoked entries | DER size | Before | After |
| --- | --- | --- | --- |
| 50,000 | 2.45 MB | 10.38 s | 5.29 s |
| 100,000 | 4.90 MB | 38.25 s | 9.89 s |

These are single local measurements using generated CRLs with 16-byte serial numbers and a keyCompromise reason extension per entry, with the `tbr_crl` profile. Timings include worker stdin/stdout and linting, and exclude startup and HTTP/network overhead. They are illustrative rather than a production latency guarantee.

### Validation

- Five Python input protocol tests pass: `python3 -B -m unittest discover -s linter/pkilint -p 'test_*.py'`.
- `go vet ./request ./linter ./linter/zlint ./linter/pkilint` passes.
- `go test -race ./request ./linter ./linter/zlint ./linter/pkilint` passes (pkilint has no Go test files).
- Before/after workers return identical reports for the large CRLs and an invalid CRL reason code. The final embedded worker also preserves responses for a certificate, malformed OCSP input, an invalid CRL, and a subsequent valid CRL in the same process.
- Full container build was not run locally.
