### PR TITLE
pkilint: avoid quadratic PEM input assembly

### DIFF
--- a/linter/pkilint/handler.go
+++ b/linter/pkilint/handler.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/pkimetal/pkimetal/config"
 	"github.com/pkimetal/pkimetal/linter"
+	"github.com/pkimetal/pkimetal/linter/pkilint/pemreader"
 )
 
 type Pkilint struct{}
@@ -186,35 +187,29 @@ def lint_ocsp_response(pem_data):
 		return "F: Exception: " + str(e)
 
 
-profile_id = -1
-pem_data = ""
+# read_pem_requests: collect normalized PEM lines and join them once per request, avoiding quadratic string assembly for large inputs (e.g. big CRLs).
+` + pemreader.Reader + `
+
 try:
 	init_smime_validators()
 	init_serverauth_validators_and_filters()
 	init_etsi_validators_and_filters()
 	print("` + linter.PKIMETAL_READY + `", flush=True)
-	for line in stdin:
-		if profile_id == -1:
-			profile_id = int(line.strip())
+	for profile_id, pem_data in read_pem_requests(stdin):
+		if profile_id in etsi_profile_ids:
+			print(lint_etsi_cert(profile_id, profile_id not in etsi_non_browser_profile_ids, pem_data))
+		elif profile_id in sbr_profile_ids:
+			print(lint_cabf_smime_cert(profile_id, pem_data))
+		elif profile_id in tbr_tevg_profile_ids:
+			print(lint_cabf_serverauth_cert(profile_id, pem_data))
+		elif profile_id in crl_profile_ids:
+			print(lint_crl(pem_data, profile_id))
+		elif profile_id in ocspresponse_profile_ids:
+			print(lint_ocsp_response(pem_data))
 		else:
-			pem_data = pem_data + line.strip() + "\n"
-
-		if "END CERTIFICATE" in line or "END X509 CRL" in line or "END OCSP RESPONSE" in line:
-			if profile_id in etsi_profile_ids:
-				print(lint_etsi_cert(profile_id, profile_id not in etsi_non_browser_profile_ids, pem_data))
-			elif profile_id in sbr_profile_ids:
-				print(lint_cabf_smime_cert(profile_id, pem_data))
-			elif profile_id in tbr_tevg_profile_ids:
-				print(lint_cabf_serverauth_cert(profile_id, pem_data))
-			elif profile_id in crl_profile_ids:
-				print(lint_crl(pem_data, profile_id))
-			elif profile_id in ocspresponse_profile_ids:
-				print(lint_ocsp_response(pem_data))
-			else:
-				print(lint_pkix_cert(pem_data))
-			print("` + linter.PKIMETAL_ENDOFRESULTS + `", flush=True)
-			profile_id = -1
-			pem_data = ""
+			print(lint_pkix_cert(pem_data))
+		print("` + linter.PKIMETAL_ENDOFRESULTS + `", flush=True)
+		del pem_data
 except KeyboardInterrupt:
 	pass
 `}

--- a/linter/pkilint/pemreader/pemreader.go
+++ b/linter/pkilint/pemreader/pemreader.go
@@ -1,0 +1,22 @@
+// Package pemreader holds the Python source for pkilint's PEM request reader.
+// It is kept in its own package so it can be unit-tested without triggering the
+// pkilint package's init(), which requires a configured pkilint install.
+package pemreader
+
+// Reader is the Python generator that reads the profile/PEM request protocol
+// from a stream.  It collects normalized PEM lines and joins them once per
+// request, avoiding quadratic string assembly for large inputs (e.g. big CRLs).
+const Reader = `def read_pem_requests(stream):
+	profile_id = None
+	pem_lines = []
+	for line in stream:
+		if profile_id is None:
+			profile_id = int(line.strip())
+		else:
+			pem_lines.append(line.strip() + "\n")
+
+		if "END CERTIFICATE" in line or "END X509 CRL" in line or "END OCSP RESPONSE" in line:
+			yield profile_id, "".join(pem_lines)
+			profile_id = None
+			pem_lines.clear()
+`

--- a/linter/pkilint/pemreader/pemreader_test.go
+++ b/linter/pkilint/pemreader/pemreader_test.go
@@ -1,0 +1,139 @@
+package pemreader
+
+import (
+	"bytes"
+	"encoding/json"
+	"os/exec"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// request is one (profile_id, pem_data) pair yielded by read_pem_requests.
+type request struct {
+	ProfileID int
+	PEMData   string
+}
+
+// runReader feeds wire into the Reader generator (executed by python3) and
+// returns the yielded requests.  It skips the test if python3 is unavailable,
+// and fails if the generator raises (e.g. an invalid profile).
+func runReader(t *testing.T, wire string) []request {
+	t.Helper()
+
+	python, err := exec.LookPath("python3")
+	if err != nil {
+		t.Skip("python3 not available")
+	}
+
+	const driver = `
+import sys, json
+for profile_id, pem_data in read_pem_requests(sys.stdin):
+	sys.stdout.write(json.dumps([profile_id, pem_data]) + "\n")
+`
+	cmd := exec.Command(python, "-c", Reader+driver)
+	cmd.Stdin = strings.NewReader(wire)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("read_pem_requests failed: %v\nstderr: %s", err, stderr.String())
+	}
+
+	var requests []request
+	for _, line := range strings.Split(strings.TrimRight(stdout.String(), "\n"), "\n") {
+		if line == "" {
+			continue
+		}
+		var pair []json.RawMessage
+		if err := json.Unmarshal([]byte(line), &pair); err != nil {
+			t.Fatalf("failed to parse %q: %v", line, err)
+		}
+		var r request
+		if err := json.Unmarshal(pair[0], &r.ProfileID); err != nil {
+			t.Fatalf("failed to parse profile id from %q: %v", line, err)
+		}
+		if err := json.Unmarshal(pair[1], &r.PEMData); err != nil {
+			t.Fatalf("failed to parse pem data from %q: %v", line, err)
+		}
+		requests = append(requests, r)
+	}
+	return requests
+}
+
+func assertRequests(t *testing.T, got, want []request) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("got %d requests, want %d: %+v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i].ProfileID != want[i].ProfileID {
+			t.Errorf("request %d: got profile id %d, want %d", i, got[i].ProfileID, want[i].ProfileID)
+		}
+		if got[i].PEMData != want[i].PEMData {
+			t.Errorf("request %d: got pem data %q, want %q", i, got[i].PEMData, want[i].PEMData)
+		}
+	}
+}
+
+func TestReadPemRequests_MultipleRequestsAndAllSupportedTypes(t *testing.T) {
+	want := []request{
+		{3, "-----BEGIN CERTIFICATE-----\nYWJj\n-----END CERTIFICATE-----\n"},
+		{32, "-----BEGIN X509 CRL-----\nZGVm\n-----END X509 CRL-----\n"},
+		{13, "-----BEGIN OCSP RESPONSE-----\nZ2hp\n-----END OCSP RESPONSE-----\n"},
+	}
+	var wire strings.Builder
+	for _, r := range want {
+		wire.WriteString(strconv.Itoa(r.ProfileID))
+		wire.WriteString("\n")
+		wire.WriteString(r.PEMData)
+	}
+	assertRequests(t, runReader(t, wire.String()), want)
+}
+
+func TestReadPemRequests_WhitespaceAndCRLFAreNormalized(t *testing.T) {
+	wire := " 32 \r\n -----BEGIN X509 CRL----- \r\n" +
+		"\tYWJj \r\n -----END X509 CRL----- \r\n"
+	want := []request{{32, "-----BEGIN X509 CRL-----\nYWJj\n-----END X509 CRL-----\n"}}
+	assertRequests(t, runReader(t, wire), want)
+}
+
+func TestReadPemRequests_LargeRequestFollowedBySmallRequest(t *testing.T) {
+	// Roughly 6 MiB of PEM, followed by another request on the same worker.
+	large := "-----BEGIN X509 CRL-----\n" +
+		strings.Repeat(strings.Repeat("A", 64)+"\n", 100000) +
+		"-----END X509 CRL-----\n"
+	small := "-----BEGIN X509 CRL-----\nYWJj\n-----END X509 CRL-----\n"
+	wire := "32\n" + large + "11\n" + small
+	want := []request{{32, large}, {11, small}}
+	assertRequests(t, runReader(t, wire), want)
+}
+
+func TestReadPemRequests_IncompleteInputIsNotDispatched(t *testing.T) {
+	for _, wire := range []string{"", "32\n", "32\n-----BEGIN X509 CRL-----\nYWJj\n"} {
+		if got := runReader(t, wire); len(got) != 0 {
+			t.Errorf("wire %q: expected no requests, got %+v", wire, got)
+		}
+	}
+}
+
+func TestReadPemRequests_InvalidProfileIsRejected(t *testing.T) {
+	python, err := exec.LookPath("python3")
+	if err != nil {
+		t.Skip("python3 not available")
+	}
+	const driver = `
+import sys
+list(read_pem_requests(sys.stdin))
+`
+	cmd := exec.Command(python, "-c", Reader+driver)
+	cmd.Stdin = strings.NewReader("invalid\n")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err == nil {
+		t.Fatal("expected read_pem_requests to raise for an invalid profile id")
+	}
+	if !strings.Contains(stderr.String(), "ValueError") {
+		t.Errorf("expected a ValueError, got stderr: %s", stderr.String())
+	}
+}


### PR DESCRIPTION
Replaces #1910.

## Problem

Large CRLs caused the pkilint worker to rebuild the entire accumulated PEM string on every input line (\`pem_data = pem_data + line.strip() + "\n"\`), making input assembly **quadratic** in the payload size. A CRL is a single PEM blob spanning many lines, so this is the dominant cost for large inputs.

## Fix

Collect normalized PEM lines in a list and join them once per request via a \`read_pem_requests\` generator (O(n)), releasing the payload after each response. Profile dispatch, supported PEM boundaries, whitespace normalization, and the READY/ENDOFRESULTS protocol are preserved.

## Difference from #1910

#1910 achieved the same algorithmic fix but embedded a standalone \`pem_input.py\` via \`//go:embed\`, breaking this handler's convention of keeping its Python inline in the Go string literal (and requiring a separate \`python -m unittest\` CI step, \`.gitignore\` entry, etc.).

Here the reader lives in a small \`linter/pkilint/pemreader\` Go package as an exported constant (\`pemreader.Reader\`) that \`handler.go\` embeds into the worker script — still a single Go source of truth, no separate \`.py\` file.

## Tests

Package \`pkilint\`'s \`init()\` panics without a configured pkilint install, so a \`_test.go\` there would break \`go test ./linter/pkilint\`. Isolating the reader in \`pemreader\` (no such init) makes it testable by plain \`go test\`. Five tests run the actual generator through \`python3\` and cover:

- all supported input types across consecutive requests
- CRLF / surrounding-whitespace normalization
- a ~6 MiB request followed by a small one on the same worker (the quadratic regression)
- incomplete input yields nothing
- an invalid profile id raises \`ValueError\`

They \`t.Skip\` when \`python3\` is unavailable, so no extra CI step is needed.